### PR TITLE
Feature/queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@raisely/restcore",
-  "version": "0.0.8",
+  "name": "@raisely/restie",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1480,6 +1480,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+    },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -2439,8 +2444,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
@@ -2464,6 +2468,23 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      }
+    },
+    "p-queue": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.0.tgz",
+      "integrity": "sha512-zPHXPNy9jZsiym0PpJjvnHQysx1fSd/QdaNVwiDRLU2KFChD6h9CkCB6b8i3U8lBwJyA+mHgNZCzcy77glUssQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raisely/restie",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "REST wrapper for fetch implementations",
   "main": "dist/restie.dist.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-terser": "^5.1.2",
     "uuid": "^3.3.3"
+  },
+  "dependencies": {
+    "p-queue": "^6.6.0"
   }
 }

--- a/spec/helpers/assertions.js
+++ b/spec/helpers/assertions.js
@@ -28,9 +28,14 @@ function assertShallowSubset(primary, compareTo) {
 	});
 }
 
+function allEqual(items, expectedValue, generateMessage = () => undefined) {
+	items.forEach((currentValue, index) => assert.strictEqual(currentValue, expectedValue, generateMessage(currentValue, index)));
+}
+
 module.exports = {
 	modelHasExpectedShape,
 	modelHasExpectedPath,
 	assertShallowSubset,
+	allEqual,
 	assert,
 }

--- a/spec/helpers/misc.js
+++ b/spec/helpers/misc.js
@@ -1,0 +1,33 @@
+/**
+ * Sends a huge batch of requests to a mocked Restie model
+ * @param apiModel The restie model to
+ * @param total The total number of requests to send
+ * @param method The method to use
+ * @return {Promise<[Results]>} Array of Restie results, corresponding to the total provided
+ */
+async function sendRequestWave(apiModel, total, method = 'get'){
+	const requests = [];
+	let totalRequests = total;
+	while (totalRequests--) requests.push(apiModel[method]());
+	return Promise.all(requests);
+}
+
+/**
+ * Basic wait helper which pauses async thread on event loop - useful for timed/caching tests
+ * @param duration The approximate amount of milliseconds to wait on the event loop
+ * @return {Promise<undefined>}
+ */
+const pause = (duration) => new Promise(resolve => setTimeout(resolve, duration));
+
+/**
+ * Runs result on all provided values
+ * @param results
+ * @return {object[]}
+ */
+const getBatchResults = results => results.map(res => res.result());
+
+module.exports = {
+	sendRequestWave,
+	pause,
+	getBatchResults
+};

--- a/spec/runtime.spec.js
+++ b/spec/runtime.spec.js
@@ -141,42 +141,42 @@ describe('runtime', () => {
 		test.assert.strictEqual((await cachedApiModel.get()).result(), '1');
 	});
 
-	// it('can cache 10K requests (5K -0, 5K -1) (TTL mode)', async function () {
-	// 	this.timeout(5000);
-	//
-	// 	// use side-effect counter to help determine that we are in fact using cache
-	// 	let counter = 0;
-	//
-	// 	const [apiUrl] = await getServer((app) => {
-	// 		app.get('/test-caching/request', (req, res) => {
-	// 			res.end(`${counter++}`);
-	// 		});
-	// 	});
-	//
-	// 	// create cached model
-	// 	const cachedApiModel = restie(apiUrl, {
-	// 		cache: true,
-	// 		cacheTtl: 1000,
-	// 	}).one('test-caching', 'request');
-	//
-	// 	// The first two batches should be performed in sequence to make sure that the Ttl isn't expiring unexpectedly
-	// 	const first = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
-	// 	await pause(900);
-	// 	const second = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
-	//
-	// 	// Wait for TTL to expire
-	// 	await pause(1100);
-	//
-	// 	const third = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
-	// 	await pause(900);
-	// 	const forth = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
-	//
-	// 	// Ensure that batches are caching separately, but also grouped by TTL timeout
-	// 	test.allEqual([...first, ...second], '0',
-	// 		(value, index) => `the ${index + 1} request made failed caching (resolved with ${value})`)
-	// 	test.allEqual([...third, ...forth], '1',
-	// 		(value, index) => `the ${index + 1} request made failed caching (resolved with ${value})`)
-	// });
+	it('can cache 10K requests (5K -0, 5K -1) (TTL mode)', async function () {
+		this.timeout(5000);
+
+		// use side-effect counter to help determine that we are in fact using cache
+		let counter = 0;
+
+		const [apiUrl] = await getServer((app) => {
+			app.get('/test-caching/request', (req, res) => {
+				res.end(`${counter++}`);
+			});
+		});
+
+		// create cached model
+		const cachedApiModel = restie(apiUrl, {
+			cache: true,
+			cacheTtl: 1000,
+		}).one('test-caching', 'request');
+
+		// The first two batches should be performed in sequence to make sure that the Ttl isn't expiring unexpectedly
+		const first = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
+		await pause(900);
+		const second = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
+
+		// Wait for TTL to expire
+		await pause(1100);
+
+		const third = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
+		await pause(900);
+		const forth = getBatchResults(await sendRequestWave(cachedApiModel, 2500));
+
+		// Ensure that batches are caching separately, but also grouped by TTL timeout
+		test.allEqual([...first, ...second], '0',
+			(value, index) => `the ${index + 1} request made failed caching (resolved with ${value})`)
+		test.allEqual([...third, ...forth], '1',
+			(value, index) => `the ${index + 1} request made failed caching (resolved with ${value})`)
+	});
 
 	it('can rate limit batches (10 bucket size @ 500 requests)', async function () {
 		this.timeout(5000);

--- a/src/restie.js
+++ b/src/restie.js
@@ -210,7 +210,10 @@ function buildRestie(baseUrl, userConfig = {}) {
 			// use the default (method:url based) calculation
 			({ fullUrl, options }) => `${options.method}:${fullUrl}`;
 
-		restieApiInstance.$cachedResponses = [];
+		// Also bind cache response storage if applicable
+		if (configuration.cacheTtl) {
+			restieApiInstance.$cachedResponses = [];
+		}
 	}
 
 	if (configuration.initialBucketSize) {

--- a/src/restie.js
+++ b/src/restie.js
@@ -177,6 +177,7 @@ function buildRestie(baseUrl, userConfig = {}) {
 		responseInterceptors: new Set(),
 		errorInterceptors: new Set(),
 		dataKey: typeof userConfig.dataKey === 'string' ? userConfig.dataKey : null,
+		initialBucketSize: userConfig.bucketSize,
 	};
 
 	const restieApiInstance = {
@@ -192,10 +193,13 @@ function buildRestie(baseUrl, userConfig = {}) {
 		all(modelBase) { return buildModel(this, baseUrl, modelBase); },
 		one(modelBase, id) { return buildDualModel(this, baseUrl, modelBase, id); },
 		custom(modelBase) { return buildModel(this, baseUrl, modelBase) },
-		setBucketSize(size) { this.$queue.concurrency = size },
+		setBucketSize(size) {
+			if (!this.$queue) return;
+			this.$queue.concurrency = size;
+		},
 	};
 
-	if (configuration.enabledCache || configuration.cacheTTL) {
+	if (configuration.enabledCache || configuration.cacheTtl) {
 		// add in cache store
 		restieApiInstance.$cacheStore = new Map();
 
@@ -209,7 +213,7 @@ function buildRestie(baseUrl, userConfig = {}) {
 		restieApiInstance.$cachedResponses = [];
 	}
 
-	if (userConfig.bucketSize) {
+	if (configuration.initialBucketSize) {
 		restieApiInstance.$queue = new PQueue({
 			concurrency: userConfig.bucketSize,
 		});

--- a/src/restie.js
+++ b/src/restie.js
@@ -1,3 +1,4 @@
+import PQueue from 'p-queue';
 
 import { basicRequestHandler } from './runtime';
 
@@ -191,6 +192,7 @@ function buildRestie(baseUrl, userConfig = {}) {
 		all(modelBase) { return buildModel(this, baseUrl, modelBase); },
 		one(modelBase, id) { return buildDualModel(this, baseUrl, modelBase, id); },
 		custom(modelBase) { return buildModel(this, baseUrl, modelBase) },
+		setBucketSize(size) { this.$queue.concurrency = size },
 	};
 
 	if (configuration.enabledCache || configuration.cacheTTL) {
@@ -205,6 +207,12 @@ function buildRestie(baseUrl, userConfig = {}) {
 			({ fullUrl, options }) => `${options.method}:${fullUrl}`;
 
 		restieApiInstance.$cachedResponses = [];
+	}
+
+	if (userConfig.bucketSize) {
+		restieApiInstance.$queue = new PQueue({
+			concurrency: userConfig.bucketSize,
+		});
 	}
 
 	if (configuration.enforceImmutability) {

--- a/src/restie.js
+++ b/src/restie.js
@@ -171,6 +171,7 @@ function buildRestie(baseUrl, userConfig = {}) {
 	const configuration = {
 		enforceImmutability: userConfig.immutable === true,
 		enabledCache: userConfig.cache === true,
+		cacheTtl: userConfig.cacheTtl,
 		requestInterceptors: new Set(),
 		responseInterceptors: new Set(),
 		errorInterceptors: new Set(),
@@ -192,7 +193,7 @@ function buildRestie(baseUrl, userConfig = {}) {
 		custom(modelBase) { return buildModel(this, baseUrl, modelBase) },
 	};
 
-	if (configuration.enabledCache) {
+	if (configuration.enabledCache || configuration.cacheTTL) {
 		// add in cache store
 		restieApiInstance.$cacheStore = new Map();
 
@@ -202,6 +203,8 @@ function buildRestie(baseUrl, userConfig = {}) {
 			userConfig.cacheBy :
 			// use the default (method:url based) calculation
 			({ fullUrl, options }) => `${options.method}:${fullUrl}`;
+
+		restieApiInstance.$cachedResponses = [];
 	}
 
 	if (configuration.enforceImmutability) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -92,7 +92,11 @@ async function commitRequest(apiRef, fullUrl, options) {
 	let rawResponse;
 
 	try {
-		rawResponse = await fetch(fullUrl, options);
+		const doFetch = () => fetch(fullUrl, options);
+		// If restie has been built with a queue, add the request to the queue
+		// and wait for it
+		const fetchPromise = apiRef.$queue ? apiRef.$queue.add(doFetch) : doFetch();
+		rawResponse = await fetchPromise;
 	} catch (fatalRequestError) {
 		fatalRequestError.statusCode = 0;
 		fatalRequestError.response = false;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -196,7 +196,11 @@ export async function basicRequestHandler(apiRef, options) {
 		return commitRequest(apiRef, prepared.fullUrl, prepared.options);
 	}
 
-	const cachedResponse = apiRef.$cachedResponses.find(r => r.$cacheKey === cacheKey);
+	// Use cached response if Ttl is being used
+	const cachedResponse =
+		apiRef.$cachedResponses &&
+		apiRef.$cachedResponses.find(r => r.$cacheKey === cacheKey);
+
 	if (cachedResponse) {
 		const cacheExpiresAt = new Date().getTime() - apiRef.configuration.cacheTtl;
 		if (cachedResponse.$cachedAt > cacheExpiresAt) {
@@ -228,14 +232,19 @@ export async function basicRequestHandler(apiRef, options) {
 		// Cache the response
 		if (apiRef.configuration.cacheTtl) {
 			console.log('response cached by restie');
+
 			finalResponse.$cacheKey = cacheKey;
 			finalResponse.$cachedAt = new Date().getTime();
+
+			// Add the newly generated response to the cache
 			apiRef.$cachedResponses.push(finalResponse);
+
 			// Limit cache size to 100 elements
 			if (apiRef.$cachedResponses.length > 100) {
 				apiRef.$cachedResponses.shift();
 			}
 		}
+
 		// resolve with the result
 		return finalResponse;
 	} catch (error) {


### PR DESCRIPTION
Adds support for passing in `{ bucketSize: 10 }` which will create a FIFO queue for requests to limit client side concurrency.
Clients can update the concurrency by doing `restie.setBucketSize(20)`