### PR TITLE
Skip caching code when ttl is 0

### DIFF
--- a/src/restie.js
+++ b/src/restie.js
@@ -197,6 +197,9 @@ function buildRestie(baseUrl, userConfig = {}) {
 			if (!this.$queue) return;
 			this.$queue.concurrency = size;
 		},
+		setCacheTtl(ttl) {
+			configuration.cacheTtl = 0;
+		},
 	};
 
 	if (configuration.enabledCache || configuration.cacheTtl) {


### PR DESCRIPTION
Just a minor change to bypass the caching code when ttl is set to zero.
In terms of blackbox behaviour this should be no change, but should result in slightly lower memory footprint and performance.